### PR TITLE
feat: add power operator and linear lexer positions with tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Responsabilidades:
 - Boolean: `true`, `false`
 
 ### Operadores
-- Aritmeticos: `+`, `-`, `*`, `/`
+- Aritmeticos: `+`, `-`, `*`, `/`, `^`
 - Concatenacion: `@`
 - Asignacion: `=`
 - Comparacion: `==`, `!=`, `<`, `>`, `<=`, `>=`
@@ -135,6 +135,9 @@ Factor         := Factor "*" Unary
 
 Unary          := "!" Unary
                 | "-" Unary
+                | Power
+
+Power          := Primary "^" Unary
                 | Primary
 
 Primary        := BuiltinCall
@@ -160,16 +163,18 @@ Literal        := "PI"
 De mayor a menor precedencia:
 
 1. Primarios: literales, identificadores, `(...)`, builtins (`sin(...)`, `log(...)`, etc.)
-2. Unarios: `!`, `-`
-3. `*`, `/`
-4. `+`, `@`, `-`
-5. `<`, `>`, `<=`, `>=`
-6. `==`, `!=`
-7. `&&`
-8. `||`
+2. Potencia: `^` (asociativa a derecha)
+3. Unarios: `!`, `-`
+4. `*`, `/`
+5. `+`, `@`, `-`
+6. `<`, `>`, `<=`, `>=`
+7. `==`, `!=`
+8. `&&`
+9. `||`
 
 Notas:
-- Los operadores binarios son asociativos a izquierda.
+- `^` es asociativo a derecha (`2 ^ 3 ^ 2` se interpreta como `2 ^ (3 ^ 2)`).
+- El resto de operadores binarios son asociativos a izquierda.
 - La asignacion (`x = ...;`) es sentencia, no expresion.
 
 ## 6. Reglas semanticas actuales
@@ -194,7 +199,7 @@ print(x);
 - `String`
 
 ### Reglas por operador
-- `+ - * /`: `Number x Number -> Number`
+- `+ - * / ^`: `Number x Number -> Number`
 - `@`: `(String,String) | (String,Number) | (Number,String) -> String`
 - `< > <= >=`: `Number x Number -> Boolean`
 - `== !=`: ambos operandos del mismo tipo (`Number`, `Boolean`, `String`) -> `Boolean`
@@ -219,7 +224,7 @@ Si no hay errores, se escribe LLVM IR en el `.txt` indicado.
 
 Incluye declaraciones para:
 - `printf`, `asprintf`, `strcmp`
-- `@llvm.sin.f64`, `@llvm.cos.f64`, `@llvm.sqrt.f64`, `@llvm.exp.f64`, `@llvm.log.f64`
+- `@llvm.sin.f64`, `@llvm.cos.f64`, `@llvm.sqrt.f64`, `@llvm.exp.f64`, `@llvm.log.f64`, `@llvm.pow.f64`
 
 Si hay errores, el `.txt` contiene diagnosticos y no IR.
 
@@ -304,9 +309,11 @@ Validos:
 - `examples/calculator_ok.hk`
 - `examples/reassignment_ok.hk`
 - `examples/builtin_math_ok.hk`
+- `examples/power_ok.hk`
 
 Con error (para validar diagnosticos):
 - `examples/builtin_math_type_error.hk`
+- `examples/power_type_error.hk`
 - `examples/error_lexical_invalid.hk`
 - `examples/error_syntax_missing_semicolon.hk`
 - `examples/error_type_mismatch_add.hk`

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,6 +42,21 @@ Números de punto flotante.
 - Literales con decimales
 - Operaciones entre floats
 
+### `builtin_math_ok.hk`
+Uso de builtins y constantes matemáticas.
+- `sin`, `cos`, `sqrt`, `exp`, `log`
+- constantes `PI` y `E`
+
+### `reassignment_ok.hk`
+Reasignación de variables.
+- `let x = ...;`
+- `x = ...;`
+
+### `power_ok.hk`
+Operador de potencia `^` con precedencia y asociatividad.
+- Potencia simple y encadenada (`2 ^ 3 ^ 2`)
+- Combinación con builtins (`sin(...) ^ 2`)
+
 ## Archivos de Prueba de Error
 
 ### `error_type_mismatch_add.hk`
@@ -83,6 +98,16 @@ Números de punto flotante.
 **Tipo de error:** Lexical
 - Tokens inválidos o malformados
 - Error esperado: Token desconocido
+
+### `builtin_math_type_error.hk`
+**Tipo de error:** Semantic - Type Mismatch
+- Llamada a `log` con tipos inválidos
+- Error esperado: `Function 'log' expects (Number, Number), but got Number and String`
+
+### `power_type_error.hk`
+**Tipo de error:** Semantic - Type Mismatch
+- Uso de `^` con `String` y `Number`
+- Error esperado: `Operator '^' expects Number and Number, but got String and Number`
 
 ## Cómo ejecutar los ejemplos
 

--- a/examples/power_ok.hk
+++ b/examples/power_ok.hk
@@ -1,0 +1,10 @@
+let base = 2;
+let expv = 3;
+
+let direct = base ^ expv;
+let chained = 2 ^ 3 ^ 2;
+let trig = sin(PI / 2) ^ 2 + cos(0);
+
+print(direct);
+print(chained);
+print(trig);

--- a/examples/power_type_error.hk
+++ b/examples/power_type_error.hk
@@ -1,0 +1,2 @@
+let bad = "hola" ^ 2;
+print(bad);

--- a/src/codegen/llvm/mod.rs
+++ b/src/codegen/llvm/mod.rs
@@ -211,7 +211,10 @@ impl LlvmBackend {
             | BuiltinFunction::Sqrt
             | BuiltinFunction::Exp => {
                 let Some(arg_expr) = args.first() else {
-                    self.semantic_error(format!("Function '{}' expects 1 argument", function.name()));
+                    self.semantic_error(format!(
+                        "Function '{}' expects 1 argument",
+                        function.name()
+                    ));
                     return None;
                 };
 
@@ -376,6 +379,23 @@ impl LlvmBackend {
 
         match op {
             BinaryOp::Concat => self.emit_concat(&left, &right),
+            BinaryOp::Pow => {
+                if left.value_type != ValueType::Double || right.value_type != ValueType::Double {
+                    self.semantic_error("Binary arithmetic operators only support numeric values");
+                    return None;
+                }
+
+                let result = self.next_temp();
+                self.emit_body(format!(
+                    "{result} = call double @llvm.pow.f64(double {}, double {})",
+                    left.repr, right.repr
+                ));
+
+                Some(ValueRef {
+                    value_type: ValueType::Double,
+                    repr: result,
+                })
+            }
             BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div => {
                 if left.value_type != ValueType::Double || right.value_type != ValueType::Double {
                     self.semantic_error("Binary arithmetic operators only support numeric values");
@@ -439,7 +459,12 @@ impl LlvmBackend {
         })
     }
 
-    fn emit_equality(&mut self, op: BinaryOp, left: &ValueRef, right: &ValueRef) -> Option<ValueRef> {
+    fn emit_equality(
+        &mut self,
+        op: BinaryOp,
+        left: &ValueRef,
+        right: &ValueRef,
+    ) -> Option<ValueRef> {
         if left.value_type != right.value_type {
             self.semantic_error("Equality operators require operands of the same type");
             return None;
@@ -533,15 +558,18 @@ impl LlvmBackend {
 
     fn emit_concat(&mut self, left: &ValueRef, right: &ValueRef) -> Option<ValueRef> {
         let (fmt_name, arg_values) = match (left.value_type, right.value_type) {
-            (ValueType::StringPtr, ValueType::StringPtr) => {
-                ("@.fmt.concat.ss", format!("i8* {}, i8* {}", left.repr, right.repr))
-            }
-            (ValueType::StringPtr, ValueType::Double) => {
-                ("@.fmt.concat.sn", format!("i8* {}, double {}", left.repr, right.repr))
-            }
-            (ValueType::Double, ValueType::StringPtr) => {
-                ("@.fmt.concat.ns", format!("double {}, i8* {}", left.repr, right.repr))
-            }
+            (ValueType::StringPtr, ValueType::StringPtr) => (
+                "@.fmt.concat.ss",
+                format!("i8* {}, i8* {}", left.repr, right.repr),
+            ),
+            (ValueType::StringPtr, ValueType::Double) => (
+                "@.fmt.concat.sn",
+                format!("i8* {}, double {}", left.repr, right.repr),
+            ),
+            (ValueType::Double, ValueType::StringPtr) => (
+                "@.fmt.concat.ns",
+                format!("double {}, i8* {}", left.repr, right.repr),
+            ),
             _ => {
                 self.semantic_error(format!(
                     "Operator '@' expects (String, String), (String, Number), or (Number, String), but got {} and {} in code generation.",
@@ -581,6 +609,7 @@ impl LlvmBackend {
             "declare double @llvm.sqrt.f64(double)".to_string(),
             "declare double @llvm.exp.f64(double)".to_string(),
             "declare double @llvm.log.f64(double)".to_string(),
+            "declare double @llvm.pow.f64(double, double)".to_string(),
             "@.fmt.number = private unnamed_addr constant [4 x i8] c\"%g\\0A\\00\"".to_string(),
             "@.fmt.string = private unnamed_addr constant [4 x i8] c\"%s\\0A\\00\"".to_string(),
             "@.fmt.bool = private unnamed_addr constant [4 x i8] c\"%d\\0A\\00\"".to_string(),

--- a/src/compiler/string_escape_tests.rs
+++ b/src/compiler/string_escape_tests.rs
@@ -40,8 +40,8 @@ print(final_msg);
     );
     assert_eq!(report.output_kind, Some(OutputKind::LlvmIr));
 
-    let llvm_ir =
-        fs::read_to_string(&output_path).expect("compiler should write llvm output file on success");
+    let llvm_ir = fs::read_to_string(&output_path)
+        .expect("compiler should write llvm output file on success");
     assert!(
         llvm_ir.contains("define i32 @main()"),
         "output file should contain LLVM IR entrypoint, got:\n{}",

--- a/src/compiler/tests.rs
+++ b/src/compiler/tests.rs
@@ -62,8 +62,8 @@ fn writes_llvm_ir_txt_for_valid_concat() {
     );
     assert_eq!(report.output_kind, Some(OutputKind::LlvmIr));
 
-    let llvm_ir =
-        fs::read_to_string(&output_path).expect("compiler should write llvm output file on success");
+    let llvm_ir = fs::read_to_string(&output_path)
+        .expect("compiler should write llvm output file on success");
     assert!(
         llvm_ir.contains("define i32 @main()"),
         "output file should contain LLVM IR entrypoint, got:\n{}",
@@ -243,6 +243,63 @@ fn writes_diagnostics_for_invalid_builtin_log_arguments() {
     assert!(
         diagnostics.contains("Function 'log' expects (Number, Number), but got Number and String."),
         "diagnostics file should contain builtin type error, got:\n{}",
+        diagnostics
+    );
+}
+
+#[test]
+fn writes_llvm_ir_for_power_operator() {
+    let source = r#"
+let a = 2 ^ 3 ^ 2;
+print(a);
+"#;
+    let output_path = unique_output_path("valid_power_ir");
+
+    let mut compiler = Compiler::new();
+    let report = compiler.compile(
+        source,
+        &CompileOptions {
+            output_path: output_path.clone(),
+        },
+    );
+
+    assert!(
+        report.errors.is_empty(),
+        "expected successful compilation, got errors: {:?}",
+        report.errors
+    );
+    assert_eq!(report.output_kind, Some(OutputKind::LlvmIr));
+
+    let llvm_ir = fs::read_to_string(&output_path)
+        .expect("compiler should write llvm output file on success");
+    assert!(
+        llvm_ir.contains("@llvm.pow.f64"),
+        "IR should include pow intrinsic, got:\n{}",
+        llvm_ir
+    );
+}
+
+#[test]
+fn writes_diagnostics_for_invalid_power_operands() {
+    let source = r#"print("x" ^ 2);"#;
+    let output_path = unique_output_path("invalid_power_operands");
+
+    let mut compiler = Compiler::new();
+    let report = compiler.compile(
+        source,
+        &CompileOptions {
+            output_path: output_path.clone(),
+        },
+    );
+
+    assert!(!report.errors.is_empty());
+    assert_eq!(report.output_kind, Some(OutputKind::Diagnostics));
+
+    let diagnostics = fs::read_to_string(&output_path)
+        .expect("compiler should write diagnostics output file on error");
+    assert!(
+        diagnostics.contains("Operator '^' expects Number and Number, but got String and Number."),
+        "diagnostics file should contain power type error, got:\n{}",
         diagnostics
     );
 }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,8 +1,8 @@
-mod token;
 #[cfg(test)]
 mod string_escape_tests;
 #[cfg(test)]
 mod tests;
+mod token;
 
 use logos::Logos;
 
@@ -42,6 +42,8 @@ enum LogosTokenKind {
     String,
     #[token("+")]
     Add,
+    #[token("^")]
+    Power,
     #[token("@")]
     Concat,
     #[token("-")]
@@ -120,6 +122,7 @@ impl LogosTokenKind {
                 (TokenKind::String(value.clone()), value)
             }
             LogosTokenKind::Add => (TokenKind::Add, lexeme.to_string()),
+            LogosTokenKind::Power => (TokenKind::Power, lexeme.to_string()),
             LogosTokenKind::Concat => (TokenKind::Concat, lexeme.to_string()),
             LogosTokenKind::Minus => (TokenKind::Minus, lexeme.to_string()),
             LogosTokenKind::Multiply => (TokenKind::Multiply, lexeme.to_string()),
@@ -166,40 +169,53 @@ impl Lexer {
 
     pub fn lex(&mut self) -> Vec<Token> {
         let input = self.input.as_str();
-        let line_starts = compute_line_starts(input);
         let mut logos_lexer = LogosTokenKind::lexer(input);
         let mut tokens = Vec::new();
         self.errors.clear();
+        let mut line = 1usize;
+        let mut column = 1usize;
+        let mut cursor = 0usize;
 
         while let Some(next) = logos_lexer.next() {
             let span = logos_lexer.span();
             let lexeme = &input[span.clone()];
-            let (line, column) = line_column_at(span.start, &line_starts);
+            advance_position(input, cursor, span.start, &mut line, &mut column);
+            let token_line = line;
+            let token_column = column;
 
             match next {
                 Ok(kind) => {
-                    tokens.push(kind.into_token(lexeme, line, column, span.start, span.end))
+                    tokens.push(kind.into_token(
+                        lexeme,
+                        token_line,
+                        token_column,
+                        span.start,
+                        span.end,
+                    ))
                 }
                 Err(_) => {
                     self.errors.push(CompilerError::new(
                         ErrorCategory::Lexical,
                         format!("Unexpected character sequence: {}", lexeme),
-                        line,
-                        column,
+                        token_line,
+                        token_column,
                     ));
                     tokens.push(Token {
                         kind: TokenKind::Unknown,
                         value: lexeme.to_string(),
-                        line,
-                        column,
+                        line: token_line,
+                        column: token_column,
                         start: span.start,
                         end: span.end,
                     });
                 }
             }
+
+            advance_position(input, span.start, span.end, &mut line, &mut column);
+            cursor = span.end;
         }
 
-        let (line, column) = line_column_at(input.len(), &line_starts);
+        advance_position(input, cursor, input.len(), &mut line, &mut column);
         tokens.push(Token {
             kind: TokenKind::EOF,
             value: String::new(),
@@ -221,23 +237,15 @@ impl Lexer {
     }
 }
 
-fn compute_line_starts(input: &str) -> Vec<usize> {
-    let mut starts = vec![0];
-    for (index, ch) in input.char_indices() {
-        if ch == '\n' {
-            starts.push(index + ch.len_utf8());
+fn advance_position(input: &str, from: usize, to: usize, line: &mut usize, column: &mut usize) {
+    for byte in &input.as_bytes()[from..to] {
+        if *byte == b'\n' {
+            *line += 1;
+            *column = 1;
+        } else {
+            *column += 1;
         }
     }
-    starts
-}
-
-fn line_column_at(offset: usize, line_starts: &[usize]) -> (usize, usize) {
-    let line_index = line_starts
-        .partition_point(|&line_start| line_start <= offset)
-        .saturating_sub(1);
-    let line_start = line_starts[line_index];
-    let column = offset.saturating_sub(line_start);
-    (line_index + 1, column + 1)
 }
 
 fn unescape_string_contents(raw: &str) -> String {

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -153,3 +153,29 @@ fn lexes_builtin_math_functions_and_constants() {
         ]
     );
 }
+
+#[test]
+fn lexes_power_operator_with_right_associative_shape() {
+    let source = r#"print(2 ^ 3 ^ 2);"#.to_string();
+    let mut lexer = Lexer::new(source);
+
+    let tokens = lexer.lex();
+    let kinds: Vec<TokenKind> = tokens.into_iter().map(|token| token.kind).collect();
+
+    assert!(!lexer.has_errors());
+    assert_eq!(
+        kinds,
+        vec![
+            TokenKind::Print,
+            TokenKind::LeftParen,
+            TokenKind::Number("2".to_string()),
+            TokenKind::Power,
+            TokenKind::Number("3".to_string()),
+            TokenKind::Power,
+            TokenKind::Number("2".to_string()),
+            TokenKind::RightParen,
+            TokenKind::Semicolon,
+            TokenKind::EOF,
+        ]
+    );
+}

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -15,6 +15,7 @@ pub enum TokenKind {
     Log,
     Assign,
     Add,
+    Power,
     Concat,
     Minus,
     Multiply,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ mod compiler;
 mod error;
 mod lexer;
 mod parser;
-mod semantic;
 mod runner;
+mod semantic;
 
 use std::{
     env, fs,
@@ -295,7 +295,10 @@ fn run_with_execution(config: RunConfig) {
                             eprint!("{}", String::from_utf8_lossy(&output.stderr));
                         }
                         if !output.status.success() {
-                            eprintln!("Program exited with status: {}", output.status.code().unwrap_or(-1));
+                            eprintln!(
+                                "Program exited with status: {}",
+                                output.status.code().unwrap_or(-1)
+                            );
                         }
                     }
                     Err(err) => {
@@ -374,9 +377,7 @@ fn parse_command() -> Result<Command, String> {
     Ok(Command::RunOne(single))
 }
 
-fn parse_run_command(
-    args: Vec<String>,
-) -> Result<Command, String> {
+fn parse_run_command(args: Vec<String>) -> Result<Command, String> {
     // Mostrar ayuda si se solicita
     if args.iter().any(|a| a == "--help" || a == "-h") {
         println!("Usage: run [<file.hk>] [options]");
@@ -444,7 +445,8 @@ fn parse_run_command(
                     let value = args_iter
                         .next()
                         .ok_or_else(|| "Missing value for --opt-level".to_string())?;
-                    opt_level = value.parse::<u8>()
+                    opt_level = value
+                        .parse::<u8>()
                         .map_err(|_| format!("Invalid optimization level: {}", value))?;
                 }
                 "--no-exec" => {
@@ -467,8 +469,7 @@ fn parse_run_command(
     }
 
     let input = input_path.ok_or_else(|| {
-        "Missing input file. Usage: run [<file.hk>] [options] [-- program_args]"
-            .to_string()
+        "Missing input file. Usage: run [<file.hk>] [options] [-- program_args]".to_string()
     })?;
 
     Ok(Command::Run(RunConfig {
@@ -541,7 +542,9 @@ fn print_usage() {
     println!();
     println!("Examples:");
     println!("  cargo run -- --emit-ir artifacts/intermediate.txt");
-    println!("  cargo run -- --input examples/calculator_ok.hk --emit-ir artifacts/calculator_ir.txt");
+    println!(
+        "  cargo run -- --input examples/calculator_ok.hk --emit-ir artifacts/calculator_ir.txt"
+    );
     println!("  cargo run -- run --input examples/calculator_ok.hk");
     println!("  cargo run -- run examples/calculator_ok.hk --opt-level 3");
     println!("  cargo run -- run examples/calculator_ok.hk -- arg1 arg2");

--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -89,6 +89,7 @@ pub struct BuiltinCallExpr {
 #[derive(Debug, Clone)]
 pub enum BinaryOp {
     Add,
+    Pow,
     Concat,
     Sub,
     Mul,

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -22,6 +22,7 @@ extern {
         "log" => TokenKind::Log,
         "=" => TokenKind::Assign,
         "+" => TokenKind::Add,
+        "^" => TokenKind::Power,
         "@" => TokenKind::Concat,
         "-" => TokenKind::Minus,
         "*" => TokenKind::Multiply,
@@ -186,6 +187,16 @@ Unary: Expr = {
     <l:@L> "-" <expr:Unary> <r:@R> => Expr::Unary(UnaryExpr {
         op: UnaryOp::Neg,
         expr: Box::new(expr),
+        span: Span::new(l, r),
+    }),
+    Power,
+};
+
+Power: Expr = {
+    <l:@L> <left:Primary> "^" <right:Unary> <r:@R> => Expr::Binary(BinaryExpr {
+        left: Box::new(left),
+        op: BinaryOp::Pow,
+        right: Box::new(right),
         span: Span::new(l, r),
     }),
     Primary,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -132,6 +132,7 @@ fn token_label(token: &TokenKind) -> String {
         TokenKind::Log => "log".to_string(),
         TokenKind::Assign => "=".to_string(),
         TokenKind::Add => "+".to_string(),
+        TokenKind::Power => "^".to_string(),
         TokenKind::Concat => "@".to_string(),
         TokenKind::Minus => "-".to_string(),
         TokenKind::Multiply => "*".to_string(),

--- a/src/parser/string_escape_tests.rs
+++ b/src/parser/string_escape_tests.rs
@@ -54,6 +54,7 @@ fn token(kind: TokenKind, start: usize, end: usize) -> Token {
         TokenKind::Log => "log".to_string(),
         TokenKind::Assign => "=".to_string(),
         TokenKind::Add => "+".to_string(),
+        TokenKind::Power => "^".to_string(),
         TokenKind::Concat => "@".to_string(),
         TokenKind::Minus => "-".to_string(),
         TokenKind::Multiply => "*".to_string(),
@@ -127,11 +128,7 @@ fn parser_normalizes_escaped_sequences_from_string_tokens() {
     let tokens = vec![
         token(TokenKind::Print, 0, 5),
         token(TokenKind::LeftParen, 5, 6),
-        token(
-            TokenKind::String("Line1\\nLine2\\tDone".to_string()),
-            6,
-            24,
-        ),
+        token(TokenKind::String("Line1\\nLine2\\tDone".to_string()), 6, 24),
         token(TokenKind::RightParen, 24, 25),
         token(TokenKind::Semicolon, 25, 26),
         token(TokenKind::EOF, 26, 26),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -231,3 +231,46 @@ fn parses_log_with_two_arguments() {
         }
     ));
 }
+
+#[test]
+fn parses_power_with_higher_precedence_than_mul_and_add() {
+    let program = parse_program(r#"print(2 + 3 * 2 ^ 3);"#);
+
+    let Statement::Print { value, .. } = &program.statements[0] else {
+        panic!("expected print statement");
+    };
+
+    let Expr::Binary(add_expr) = value else {
+        panic!("expected top-level addition");
+    };
+    assert!(matches!(add_expr.op, BinaryOp::Add));
+
+    let Expr::Binary(mul_expr) = add_expr.right.as_ref() else {
+        panic!("expected multiplication on right side of addition");
+    };
+    assert!(matches!(mul_expr.op, BinaryOp::Mul));
+
+    let Expr::Binary(pow_expr) = mul_expr.right.as_ref() else {
+        panic!("expected power expression on right side of multiplication");
+    };
+    assert!(matches!(pow_expr.op, BinaryOp::Pow));
+}
+
+#[test]
+fn parses_power_as_right_associative() {
+    let program = parse_program(r#"print(2 ^ 3 ^ 2);"#);
+
+    let Statement::Print { value, .. } = &program.statements[0] else {
+        panic!("expected print statement");
+    };
+
+    let Expr::Binary(outer_pow) = value else {
+        panic!("expected top-level power expression");
+    };
+    assert!(matches!(outer_pow.op, BinaryOp::Pow));
+
+    let Expr::Binary(inner_pow) = outer_pow.right.as_ref() else {
+        panic!("expected right-nested power expression");
+    };
+    assert!(matches!(inner_pow.op, BinaryOp::Pow));
+}

--- a/src/runner/error.rs
+++ b/src/runner/error.rs
@@ -56,7 +56,11 @@ impl fmt::Display for RunnerError {
                 source,
             } => {
                 if let Some(p) = path {
-                    write!(f, "I/O error while {action} '{path}': {source}", path = p.display())
+                    write!(
+                        f,
+                        "I/O error while {action} '{path}': {source}",
+                        path = p.display()
+                    )
                 } else {
                     write!(f, "I/O error while {action}: {source}")
                 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -94,9 +94,7 @@ impl LlvmRunner {
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap_or("output");
-            let dirname = ll_path
-                .parent()
-                .unwrap_or_else(|| Path::new("."));
+            let dirname = ll_path.parent().unwrap_or_else(|| Path::new("."));
             Platform::as_executable_path(&dirname.join(stem))
         };
 
@@ -167,9 +165,8 @@ impl LlvmRunner {
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
 
-        cmd.output().map_err(|e| {
-            RunnerError::io("executing program", Some(exe_path.to_path_buf()), e)
-        })
+        cmd.output()
+            .map_err(|e| RunnerError::io("executing program", Some(exe_path.to_path_buf()), e))
     }
 }
 

--- a/src/semantic/mod.rs
+++ b/src/semantic/mod.rs
@@ -6,7 +6,9 @@ mod tests;
 
 use crate::{
     error::{CompilerError, ErrorCategory, offset_to_line_column},
-    parser::expression::{BinaryOp, BuiltinFunction, Expr, Literal, Program, Span, Statement, UnaryOp},
+    parser::expression::{
+        BinaryOp, BuiltinFunction, Expr, Literal, Program, Span, Statement, UnaryOp,
+    },
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -165,7 +167,9 @@ impl SemanticAnalyzer {
                     }
                 }
             }
-            Expr::BuiltinCall(call) => self.check_builtin_call(call.function, &call.args, call.span, source),
+            Expr::BuiltinCall(call) => {
+                self.check_builtin_call(call.function, &call.args, call.span, source)
+            }
             Expr::Binary(binary) => {
                 let left_type = self.check_expr(&binary.left, source);
                 let right_type = self.check_expr(&binary.right, source);
@@ -175,7 +179,11 @@ impl SemanticAnalyzer {
                 };
 
                 match binary.op {
-                    BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div => {
+                    BinaryOp::Add
+                    | BinaryOp::Sub
+                    | BinaryOp::Mul
+                    | BinaryOp::Div
+                    | BinaryOp::Pow => {
                         if left_type == SemanticType::Unknown || right_type == SemanticType::Unknown
                         {
                             return Some(SemanticType::Unknown);
@@ -408,6 +416,7 @@ impl SemanticAnalyzer {
 fn op_symbol(op: BinaryOp) -> &'static str {
     match op {
         BinaryOp::Add => "+",
+        BinaryOp::Pow => "^",
         BinaryOp::Concat => "@",
         BinaryOp::Sub => "-",
         BinaryOp::Mul => "*",

--- a/src/semantic/string_escape_tests.rs
+++ b/src/semantic/string_escape_tests.rs
@@ -1,8 +1,4 @@
-use crate::{
-    error::ErrorCategory,
-    lexer::Lexer,
-    parser::Parser,
-};
+use crate::{error::ErrorCategory, lexer::Lexer, parser::Parser};
 
 use super::SemanticAnalyzer;
 

--- a/src/semantic/tests.rs
+++ b/src/semantic/tests.rs
@@ -1,8 +1,4 @@
-use crate::{
-    error::ErrorCategory,
-    lexer::Lexer,
-    parser::Parser,
-};
+use crate::{error::ErrorCategory, lexer::Lexer, parser::Parser};
 
 use super::SemanticAnalyzer;
 
@@ -208,5 +204,33 @@ fn rejects_sin_with_non_numeric_argument() {
     assert_eq!(
         errors[0].message,
         "Function 'sin' expects Number, but got Boolean."
+    );
+}
+
+#[test]
+fn allows_power_with_numeric_operands() {
+    let source = r#"
+let result = 2 ^ 3 ^ 2;
+print(result);
+"#;
+
+    let errors = analyze_source(source);
+    assert!(
+        errors.is_empty(),
+        "expected no semantic errors, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn rejects_power_with_non_numeric_operands() {
+    let source = r#"print("x" ^ 2);"#;
+
+    let errors = analyze_source(source);
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].category, ErrorCategory::Type);
+    assert_eq!(
+        errors[0].message,
+        "Operator '^' expects Number and Number, but got String and Number."
     );
 }


### PR DESCRIPTION
Implement '^' across lexer/parser/semantic/LLVM, add examples and phase tests, and switch lexer line/column tracking to linear incremental scanning. Update README and examples docs to describe grammar, precedence, builtins, and usage flow.