### PR TITLE
fix: show actual type names in error messages instead of generic 'Str…

### DIFF
--- a/src/codegen/llvm/backend/emit/expr/binary.rs
+++ b/src/codegen/llvm/backend/emit/expr/binary.rs
@@ -134,8 +134,8 @@ impl LlvmBackend {
                     } else {
                         "!="
                     },
-                    left.value_type.display_name(),
-                    right.value_type.display_name()
+                    self.type_name_for_value_type(left.value_type),
+                    self.type_name_for_value_type(right.value_type)
                 ));
                 return None;
             }
@@ -308,8 +308,8 @@ impl LlvmBackend {
                     "Operator '@' expects (String, String), (String, Number), \
                      (Number, String), (Boolean, String), or (String, Boolean), \
                      but got {} and {} in code generation.",
-                    left.value_type.display_name(),
-                    right.value_type.display_name()
+                    self.type_name_for_value_type(left.value_type),
+                    self.type_name_for_value_type(right.value_type)
                 ));
                 return None;
             }

--- a/src/codegen/llvm/backend/emit/expr/call.rs
+++ b/src/codegen/llvm/backend/emit/expr/call.rs
@@ -160,8 +160,8 @@ impl LlvmBackend {
                     "Function '{}' argument #{} expects {}, but got {}.",
                     call.name,
                     index + 1,
-                    expected.display_name(),
-                    value.value_type.display_name()
+                    self.type_name_for_value_type(expected),
+                    self.type_name_for_value_type(value.value_type)
                 ));
                 return None;
             }
@@ -171,8 +171,8 @@ impl LlvmBackend {
                     "Function '{}' argument #{} expects {}, but got {}.",
                     call.name,
                     index + 1,
-                    expected.display_name(),
-                    value.value_type.display_name()
+                    self.type_name_for_value_type(expected),
+                    self.type_name_for_value_type(value.value_type)
                 ));
                 return None;
             };
@@ -212,7 +212,7 @@ impl LlvmBackend {
         let ValueType::Struct(type_id) = receiver.value_type else {
             self.semantic_error(format!(
                 "Method call expects a struct instance receiver, but got {}.",
-                receiver.value_type.display_name()
+                self.type_name_for_value_type(receiver.value_type)
             ));
             return None;
         };
@@ -268,8 +268,8 @@ impl LlvmBackend {
                     "Method '{}' argument #{} expects {}, but got {}.",
                     call.method_name,
                     index + 1,
-                    expected.display_name(),
-                    value.value_type.display_name()
+                    self.type_name_for_value_type(expected),
+                    self.type_name_for_value_type(value.value_type)
                 ));
                 return None;
             }
@@ -279,8 +279,8 @@ impl LlvmBackend {
                     "Method '{}' argument #{} expects {}, but got {}.",
                     call.method_name,
                     index + 1,
-                    expected.display_name(),
-                    value.value_type.display_name()
+                    self.type_name_for_value_type(expected),
+                    self.type_name_for_value_type(value.value_type)
                 ));
                 return None;
             };

--- a/src/codegen/llvm/backend/emit/expr/destructive_assign.rs
+++ b/src/codegen/llvm/backend/emit/expr/destructive_assign.rs
@@ -55,7 +55,7 @@ impl LlvmBackend {
                 let ValueType::Struct(type_id) = object_ref.value_type else {
                     self.semantic_error(format!(
                         "Member assignment expects a struct instance, but got {}.",
-                        object_ref.value_type.display_name()
+                        self.type_name_for_value_type(object_ref.value_type)
                     ));
                     return None;
                 };
@@ -73,8 +73,8 @@ impl LlvmBackend {
                 {
                     self.semantic_error(format!(
                         "Destructive assignment ':=' requires type {}, but expression is {}.",
-                        field_layout.value_type.display_name(),
-                        value_ref.value_type.display_name()
+                        self.type_name_for_value_type(field_layout.value_type),
+                        self.type_name_for_value_type(value_ref.value_type)
                     ));
                     return None;
                 }
@@ -84,8 +84,8 @@ impl LlvmBackend {
                 else {
                     self.semantic_error(format!(
                         "Destructive assignment ':=' requires type {}, but expression is {}.",
-                        field_layout.value_type.display_name(),
-                        value_ref.value_type.display_name()
+                        self.type_name_for_value_type(field_layout.value_type),
+                        self.type_name_for_value_type(value_ref.value_type)
                     ));
                     return None;
                 };

--- a/src/codegen/llvm/backend/emit/expr/if_expr.rs
+++ b/src/codegen/llvm/backend/emit/expr/if_expr.rs
@@ -63,8 +63,8 @@
 //             if elif_value.value_type != result_type {
 //                 self.semantic_error(format!(
 //                     "Elif branch returns {} but expected {}",
-//                     elif_value.value_type.display_name(),
-//                     result_type.display_name()
+//                     self.type_name_for_value_type(elif_value.value_type),
+//                     self.type_name_for_value_type(result_type)
 //                 ));
 //                 return None;
 //             }
@@ -80,8 +80,8 @@
 //         if else_value.value_type != result_type {
 //             self.semantic_error(format!(
 //                 "Else branch returns {} but expected {}",
-//                 else_value.value_type.display_name(),
-//                 result_type.display_name()
+//                 self.type_name_for_value_type(else_value.value_type),
+//                 self.type_name_for_value_type(result_type)
 //             ));
 //             return None;
 //         }
@@ -207,8 +207,8 @@ impl LlvmBackend {
                 if elif_value.value_type != result_type {
                     self.semantic_error(format!(
                         "Elif branch returns {} but expected {}",
-                        elif_value.value_type.display_name(),
-                        result_type.display_name()
+                        self.type_name_for_value_type(elif_value.value_type),
+                        self.type_name_for_value_type(result_type)
                     ));
                     return None;
                 }
@@ -242,8 +242,8 @@ impl LlvmBackend {
             if else_value.value_type != result_type {
                 self.semantic_error(format!(
                     "Else branch returns {} but expected {}",
-                    else_value.value_type.display_name(),
-                    result_type.display_name()
+                    self.type_name_for_value_type(else_value.value_type),
+                    self.type_name_for_value_type(result_type)
                 ));
                 return None;
             }

--- a/src/codegen/llvm/backend/emit/expr/member_access.rs
+++ b/src/codegen/llvm/backend/emit/expr/member_access.rs
@@ -12,7 +12,7 @@ impl LlvmBackend {
         let ValueType::Struct(type_id) = object.value_type else {
             self.semantic_error(format!(
                 "Member access expects a struct instance, but got {}.",
-                object.value_type.display_name()
+                self.type_name_for_value_type(object.value_type)
             ));
             return None;
         };

--- a/src/codegen/llvm/backend/emit/expr/new_expr.rs
+++ b/src/codegen/llvm/backend/emit/expr/new_expr.rs
@@ -76,8 +76,8 @@ impl LlvmBackend {
                     "Type '{}' constructor parameter '{}' expects {}, but got {}.",
                     new_expr.type_name,
                     param.name,
-                    expected_type.display_name(),
-                    value.value_type.display_name()
+                    self.type_name_for_value_type(expected_type),
+                    self.type_name_for_value_type(value.value_type)
                 ));
                 self.pop_scope();
                 return None;
@@ -88,8 +88,8 @@ impl LlvmBackend {
                     "Type '{}' constructor parameter '{}' expects {}, but got {}.",
                     new_expr.type_name,
                     param.name,
-                    expected_type.display_name(),
-                    value.value_type.display_name()
+                    self.type_name_for_value_type(expected_type),
+                    self.type_name_for_value_type(value.value_type)
                 ));
                 self.pop_scope();
                 return None;
@@ -174,8 +174,8 @@ impl LlvmBackend {
                     "Attribute '{}' in type '{}' expects {}, but initializer produced {}.",
                     attribute.name,
                     concrete_type_name,
-                    field_layout.value_type.display_name(),
-                    value.value_type.display_name()
+                    self.type_name_for_value_type(field_layout.value_type),
+                    self.type_name_for_value_type(value.value_type)
                 ));
                 return false;
             }
@@ -186,8 +186,8 @@ impl LlvmBackend {
                     "Attribute '{}' in type '{}' expects {}, but initializer produced {}.",
                     attribute.name,
                     concrete_type_name,
-                    field_layout.value_type.display_name(),
-                    value.value_type.display_name()
+                    self.type_name_for_value_type(field_layout.value_type),
+                    self.type_name_for_value_type(value.value_type)
                 ));
                 return false;
             };
@@ -222,8 +222,8 @@ impl LlvmBackend {
                     "Type '{}' constructor parameter '{}' expects {}, but got {}.",
                     type_name,
                     param.name,
-                    expected_type.display_name(),
-                    value.value_type.display_name()
+                    self.type_name_for_value_type(expected_type),
+                    self.type_name_for_value_type(value.value_type)
                 ));
                 return false;
             }
@@ -233,8 +233,8 @@ impl LlvmBackend {
                     "Type '{}' constructor parameter '{}' expects {}, but got {}.",
                     type_name,
                     param.name,
-                    expected_type.display_name(),
-                    value.value_type.display_name()
+                    self.type_name_for_value_type(expected_type),
+                    self.type_name_for_value_type(value.value_type)
                 ));
                 return false;
             };

--- a/src/codegen/llvm/backend/emit/function.rs
+++ b/src/codegen/llvm/backend/emit/function.rs
@@ -59,8 +59,8 @@ impl LlvmBackend {
             self.semantic_error(format!(
                 "Function '{}' returns {} but inferred signature expects {}.",
                 function.name,
-                result.value_type.display_name(),
-                info.return_type.display_name()
+                self.type_name_for_value_type(result.value_type),
+                self.type_name_for_value_type(info.return_type)
             ));
             self.scopes = saved_scopes;
             self.body_lines = saved_body;

--- a/src/codegen/llvm/backend/emit/method.rs
+++ b/src/codegen/llvm/backend/emit/method.rs
@@ -89,8 +89,8 @@ impl LlvmBackend {
                 "Method '{}.{}' returns {} but inferred signature expects {}.",
                 type_decl.name,
                 method.name,
-                result.value_type.display_name(),
-                info.return_type.display_name()
+                self.type_name_for_value_type(result.value_type),
+                self.type_name_for_value_type(info.return_type)
             ));
             self.scopes = saved_scopes;
             self.body_lines = saved_body;

--- a/src/codegen/llvm/backend/emit/statement.rs
+++ b/src/codegen/llvm/backend/emit/statement.rs
@@ -105,7 +105,7 @@ impl LlvmBackend {
             ValueType::Null | ValueType::Function | ValueType::Struct(_) => {
                 self.semantic_error(format!(
                     "Function 'print' cannot print values of type {}.",
-                    value_ref.value_type.display_name()
+                    self.type_name_for_value_type(value_ref.value_type)
                 ));
             }
         }

--- a/src/codegen/llvm/backend/mod.rs
+++ b/src/codegen/llvm/backend/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     parser::expression::{Program, TypeDecl},
 };
 
-use super::helper::state::{ValueRef, VariableInfo};
+use super::helper::state::{ValueRef, ValueType, VariableInfo};
 use functions::FunctionInfo;
 use layout::StructLayout;
 
@@ -97,6 +97,19 @@ impl LlvmBackend {
     pub(super) fn semantic_error(&mut self, message: impl Into<String>) {
         self.errors
             .push(CompilerError::new(ErrorCategory::Semantic, message, 1, 1));
+    }
+
+    pub(super) fn type_name_for_value_type(&self, vt: ValueType) -> String {
+        match vt {
+            ValueType::Struct(id) => {
+                self.type_ids
+                    .iter()
+                    .find(|(_, tid)| **tid == id)
+                    .map(|(name, _)| name.clone())
+                    .unwrap_or_else(|| "Struct".to_string())
+            }
+            _ => vt.display_name().to_string(),
+        }
     }
 
     pub(super) fn push_scope(&mut self) {

--- a/src/semantic/helper/types_namespace/types.rs
+++ b/src/semantic/helper/types_namespace/types.rs
@@ -1,3 +1,5 @@
+use super::TypeTable;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SemanticType {
     Number,
@@ -21,6 +23,37 @@ impl SemanticType {
             SemanticType::Function(_) => "Function",
             SemanticType::Struct(_) => "Struct",
             SemanticType::Unknown => "Unknown",
+        }
+    }
+
+    pub(in crate::semantic) fn display_name_with_table(self, table: &TypeTable) -> String {
+        match self {
+            SemanticType::Number => "Number".to_string(),
+            SemanticType::Boolean => "Boolean".to_string(),
+            SemanticType::String => "String".to_string(),
+            SemanticType::Unit => "Unit".to_string(),
+            SemanticType::Null => "Null".to_string(),
+            SemanticType::Unknown => "Unknown".to_string(),
+            SemanticType::Struct(id) => {
+                let type_id = super::TypeId(id);
+                table
+                    .get_struct(type_id)
+                    .map(|info| info.name.clone())
+                    .unwrap_or_else(|| "Struct".to_string())
+            }
+            SemanticType::Function(id) => {
+                let type_id = super::TypeId(id);
+                table
+                    .get_function(type_id)
+                    .map(|info| {
+                        if info.is_method() {
+                            "Method".to_string()
+                        } else {
+                            "Function".to_string()
+                        }
+                    })
+                    .unwrap_or_else(|| "Function".to_string())
+            }
         }
     }
 

--- a/src/semantic/pipeline/type_checker/binary_expr_checker.rs
+++ b/src/semantic/pipeline/type_checker/binary_expr_checker.rs
@@ -46,8 +46,8 @@ impl<'a> TypeChecker<'a> {
                         format!(
                             "Operator '{}' expects Number and Number, but got {} and {}.",
                             op_name,
-                            left_type.display_name(),
-                            right_type.display_name()
+                            left_type.display_name_with_table(&self.analyzer.type_table),
+                            right_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     None
@@ -87,8 +87,8 @@ impl<'a> TypeChecker<'a> {
                         source,
                         format!(
                             "Operator '@' expects (String, String), (String, Number), or (Number, String), but got {} and {}.",
-                            left_type.display_name(),
-                            right_type.display_name()
+                            left_type.display_name_with_table(&self.analyzer.type_table),
+                            right_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     None
@@ -128,8 +128,8 @@ impl<'a> TypeChecker<'a> {
                         source,
                         format!(
                             "Operator '@@' expects (String, String), (String, Number), or (Number, String), but got {} and {}.",
-                            left_type.display_name(),
-                            right_type.display_name()
+                            left_type.display_name_with_table(&self.analyzer.type_table),
+                            right_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     None
@@ -166,8 +166,8 @@ impl<'a> TypeChecker<'a> {
                         format!(
                             "Comparison operator '{}' expects Number and Number, but got {} and {}.",
                             op_symbol(binary.op.clone()),
-                            left_type.display_name(),
-                            right_type.display_name()
+                            left_type.display_name_with_table(&self.analyzer.type_table),
+                            right_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     None
@@ -206,8 +206,8 @@ impl<'a> TypeChecker<'a> {
                         format!(
                             "Operator '{}' compares 'Null' only with nullable operands, but got {} and {}.",
                             op_symbol(binary.op.clone()),
-                            left_type.display_name(),
-                            right_type.display_name()
+                            left_type.display_name_with_table(&self.analyzer.type_table),
+                            right_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     return None;
@@ -220,8 +220,8 @@ impl<'a> TypeChecker<'a> {
                         format!(
                             "Operator '{}' expects operands of the same type, but got {} and {}.",
                             op_symbol(binary.op.clone()),
-                            left_type.display_name(),
-                            right_type.display_name()
+                            left_type.display_name_with_table(&self.analyzer.type_table),
+                            right_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     return None;

--- a/src/semantic/pipeline/type_checker/builtin_call_expr_checker.rs
+++ b/src/semantic/pipeline/type_checker/builtin_call_expr_checker.rs
@@ -40,7 +40,7 @@ impl<'a> TypeChecker<'a> {
                 source,
                 format!(
                     "Function 'print' cannot print values of type {}.",
-                    arg_type.display_name()
+                    arg_type.display_name_with_table(&self.analyzer.type_table)
                 ),
             );
             return None;
@@ -105,7 +105,7 @@ impl<'a> TypeChecker<'a> {
                         format!(
                             "Function '{}' expects Number, but got {}.",
                             function.name(),
-                            arg_type.display_name()
+                            arg_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     None
@@ -151,8 +151,8 @@ impl<'a> TypeChecker<'a> {
                         source,
                         format!(
                             "Function 'log' expects (Number, Number), but got {} and {}.",
-                            left_type.display_name(),
-                            right_type.display_name()
+                            left_type.display_name_with_table(&self.analyzer.type_table),
+                            right_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     None

--- a/src/semantic/pipeline/type_checker/destructive_assign_expr_checker.rs
+++ b/src/semantic/pipeline/type_checker/destructive_assign_expr_checker.rs
@@ -70,7 +70,7 @@ impl<'a> TypeChecker<'a> {
                         source,
                         format!(
                             "Member assignment expects a struct instance, but got {}.",
-                            receiver_type.display_name()
+                            receiver_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     return None;
@@ -120,8 +120,8 @@ impl<'a> TypeChecker<'a> {
                         source,
                         format!(
                             "Destructive assignment ':=' requires type {}, but expression is {}.",
-                            expected_type.display_name(),
-                            value_type.display_name()
+                            expected_type.display_name_with_table(&self.analyzer.type_table),
+                            value_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     return None;

--- a/src/semantic/pipeline/type_checker/function_call_expr_checker.rs
+++ b/src/semantic/pipeline/type_checker/function_call_expr_checker.rs
@@ -91,8 +91,8 @@ impl<'a> TypeChecker<'a> {
                         "Function '{}' argument #{} expects {}, but got {}.",
                         call.name,
                         index + 1,
-                        expected_type.display_name(),
-                        arg_type.display_name()
+                        expected_type.display_name_with_table(&self.analyzer.type_table),
+                        arg_type.display_name_with_table(&self.analyzer.type_table)
                     ),
                 );
                 valid_call = false;

--- a/src/semantic/pipeline/type_checker/if_expr_checker.rs
+++ b/src/semantic/pipeline/type_checker/if_expr_checker.rs
@@ -64,8 +64,8 @@ impl<'a> TypeChecker<'a> {
                     source,
                     format!(
                         "If branches must return the same type, but got {} and {}.",
-                        expected_type.display_name(),
-                        actual_type.display_name()
+                        expected_type.display_name_with_table(&self.analyzer.type_table),
+                        actual_type.display_name_with_table(&self.analyzer.type_table)
                     ),
                 );
                 return None;
@@ -96,7 +96,7 @@ impl<'a> TypeChecker<'a> {
                     source,
                     format!(
                         "If condition expects Boolean, but got {}.",
-                        condition_type.display_name()
+                        condition_type.display_name_with_table(&self.analyzer.type_table)
                     ),
                 );
                 false

--- a/src/semantic/pipeline/type_checker/member_access_expr_checker.rs
+++ b/src/semantic/pipeline/type_checker/member_access_expr_checker.rs
@@ -13,7 +13,7 @@ impl<'a> TypeChecker<'a> {
                 source,
                 format!(
                     "Member access expects a struct instance, but got {}.",
-                    object_type.display_name()
+                    object_type.display_name_with_table(&self.analyzer.type_table)
                 ),
             );
             return None;

--- a/src/semantic/pipeline/type_checker/method_call_expr_checker.rs
+++ b/src/semantic/pipeline/type_checker/method_call_expr_checker.rs
@@ -13,7 +13,7 @@ impl<'a> TypeChecker<'a> {
                 source,
                 format!(
                     "Method call expects a struct instance receiver, but got {}.",
-                    receiver_type.display_name()
+                    receiver_type.display_name_with_table(&self.analyzer.type_table)
                 ),
             );
             return None;
@@ -161,8 +161,8 @@ impl<'a> TypeChecker<'a> {
                         "Method '{}' argument #{} expects {}, but got {}.",
                         call.method_name,
                         index + 1,
-                        expected_type.display_name(),
-                        arg_type.display_name()
+                        expected_type.display_name_with_table(&self.analyzer.type_table),
+                        arg_type.display_name_with_table(&self.analyzer.type_table)
                     ),
                 );
                 valid_call = false;

--- a/src/semantic/pipeline/type_checker/mod.rs
+++ b/src/semantic/pipeline/type_checker/mod.rs
@@ -189,8 +189,8 @@ impl<'a> TypeChecker<'a> {
                     format!(
                         "Type annotation for variable '{}' expects {}, but initializer is {}.",
                         variable_name,
-                        annotation_type.display_name(),
-                        value_type.display_name()
+                        annotation_type.display_name_with_table(&self.analyzer.type_table),
+                        value_type.display_name_with_table(&self.analyzer.type_table)
                     ),
                 );
             }
@@ -209,8 +209,8 @@ impl<'a> TypeChecker<'a> {
                     format!(
                         "Type annotation for variable '{}' expects {}, but initializer is {}.",
                         variable_name,
-                        annotation_type.display_name(),
-                        value_type.display_name()
+                        annotation_type.display_name_with_table(&self.analyzer.type_table),
+                        value_type.display_name_with_table(&self.analyzer.type_table)
                     ),
                 );
             }
@@ -248,7 +248,7 @@ impl<'a> TypeChecker<'a> {
                     .get_struct(annotation_id)
                     .map(|info| info.name.clone())
                     .unwrap_or_default(),
-                value_type.display_name()
+                value_type.display_name_with_table(&self.analyzer.type_table)
             ),
         );
         annotation_type
@@ -439,22 +439,22 @@ impl<'a> TypeChecker<'a> {
                     })
                     .unwrap_or(SemanticType::Unknown);
 
-                if expected_type != SemanticType::Unknown
-                    && arg_type != SemanticType::Unknown
-                    && !self.types_compatible(expected_type, arg_type)
-                {
-                    self.analyzer.push_type_error(
-                        arg.span(),
-                        source,
-                        format!(
-                            "Parent type '{}' constructor argument #{} expects {}, but got {}.",
-                            parent_name,
-                            index + 1,
-                            expected_type.display_name(),
-                            arg_type.display_name()
-                        ),
-                    );
-                }
+                    if expected_type != SemanticType::Unknown
+                        && arg_type != SemanticType::Unknown
+                        && !self.types_compatible(expected_type, arg_type)
+                    {
+                        self.analyzer.push_type_error(
+                            arg.span(),
+                            source,
+                            format!(
+                                "Parent type '{}' constructor argument #{} expects {}, but got {}.",
+                                parent_name,
+                                index + 1,
+                                expected_type.display_name_with_table(&self.analyzer.type_table),
+                                arg_type.display_name_with_table(&self.analyzer.type_table)
+                            ),
+                        );
+                    }
             }
         }
 
@@ -497,8 +497,8 @@ impl<'a> TypeChecker<'a> {
                                 "Type annotation for attribute '{}' in type '{}' expects {}, but initializer is {}.",
                                 attribute.name,
                                 type_decl.name,
-                                annotation_type.display_name(),
-                                value_type.display_name()
+                                annotation_type.display_name_with_table(&self.analyzer.type_table),
+                                value_type.display_name_with_table(&self.analyzer.type_table)
                             ),
                         );
                     }

--- a/src/semantic/pipeline/type_checker/new_expr_checker.rs
+++ b/src/semantic/pipeline/type_checker/new_expr_checker.rs
@@ -74,8 +74,8 @@ impl<'a> TypeChecker<'a> {
                         "Type '{}' constructor argument #{} expects {}, but got {}.",
                         new_expr.type_name,
                         index + 1,
-                        expected_type.display_name(),
-                        arg_type.display_name()
+                        expected_type.display_name_with_table(&self.analyzer.type_table),
+                        arg_type.display_name_with_table(&self.analyzer.type_table)
                     ),
                 );
                 return None;

--- a/src/semantic/pipeline/type_checker/protocol_checker.rs
+++ b/src/semantic/pipeline/type_checker/protocol_checker.rs
@@ -192,8 +192,8 @@ impl ProtocolChecker {
                         "Type does not conform to protocol: method '{}' argument #{} has incompatible variance: expected {} (contravariant) in protocol, got {}.",
                         method_name,
                         index + 1,
-                        proto_t.display_name(),
-                        impl_t.display_name()
+                        proto_t.display_name_with_table(&analyzer.type_table),
+                        impl_t.display_name_with_table(&analyzer.type_table)
                     ),
                 );
                 return None;
@@ -208,8 +208,8 @@ impl ProtocolChecker {
                 format!(
                     "Type does not conform to protocol: method '{}' return type is incompatible (covariant): expected {} in protocol, got {}.",
                     method_name,
-                    protocol_signature.return_type.display_name(),
-                    impl_signature.return_type.display_name()
+                    protocol_signature.return_type.display_name_with_table(&analyzer.type_table),
+                    impl_signature.return_type.display_name_with_table(&analyzer.type_table)
                 ),
             );
             return None;

--- a/src/semantic/pipeline/type_checker/unary_expr_checker.rs
+++ b/src/semantic/pipeline/type_checker/unary_expr_checker.rs
@@ -31,7 +31,7 @@ impl<'a> TypeChecker<'a> {
                         source,
                         format!(
                             "Unary '-' expects Number, but got {}.",
-                            expr_type.display_name()
+                            expr_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     None
@@ -59,7 +59,7 @@ impl<'a> TypeChecker<'a> {
                         source,
                         format!(
                             "Unary '!' expects Boolean, but got {}.",
-                            expr_type.display_name()
+                            expr_type.display_name_with_table(&self.analyzer.type_table)
                         ),
                     );
                     None

--- a/src/semantic/pipeline/type_checker/while_expr_checker.rs
+++ b/src/semantic/pipeline/type_checker/while_expr_checker.rs
@@ -26,7 +26,7 @@ impl<'a> TypeChecker<'a> {
                 source,
                 format!(
                     "While condition expects Boolean, but got {}.",
-                    condition_type.display_name()
+                    condition_type.display_name_with_table(&self.analyzer.type_table)
                 ),
             );
             return None;

--- a/src/semantic/pipeline/type_constraint_engine.rs
+++ b/src/semantic/pipeline/type_constraint_engine.rs
@@ -94,8 +94,8 @@ impl TypeConstraintEngine {
                     format!(
                         "Type inference conflict for variable '{}': {} vs {}.",
                         name,
-                        left.display_name(),
-                        right.display_name()
+                        left.display_name_with_table(&checker.analyzer.type_table),
+                        right.display_name_with_table(&checker.analyzer.type_table)
                     ),
                 );
                 current_type
@@ -137,8 +137,8 @@ impl TypeConstraintEngine {
                         "Function '{}' argument #{} has conflicting types: {} vs {}.",
                         function_name,
                         param_index + 1,
-                        left.display_name(),
-                        right.display_name()
+                        left.display_name_with_table(&checker.analyzer.type_table),
+                        right.display_name_with_table(&checker.analyzer.type_table)
                     ),
                 );
                 current_type
@@ -178,8 +178,8 @@ impl TypeConstraintEngine {
                     format!(
                         "Function '{}' return type conflict: {} vs {}.",
                         function_name,
-                        left.display_name(),
-                        right.display_name()
+                        left.display_name_with_table(&checker.analyzer.type_table),
+                        right.display_name_with_table(&checker.analyzer.type_table)
                     ),
                 );
                 current_type


### PR DESCRIPTION
- Add `display_name_with_table()` to SemanticType for semantic pipeline
- Add `type_name_for_value_type()` to LlvmBackend for codegen errors
- Update all error message generation to resolve concrete type names